### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      charmbracelet:
+        patterns:
+          - "github.com/charmbracelet/*"
+      dev:
+        patterns:
+          - "github.com/sqlc-dev/*"
+          - "github.com/pressly/goose*"
+          - "gotest.tools/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,14 @@ updates:
       golang-x:
         patterns:
           - "golang.org/x/*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
Dependabot is now configured in `.github/dependabot.yml` to cover both Go modules and GitHub Actions: Go updates run weekly on Mondays at 04:00 UTC with grouped PRs for Charmbracelet, Dev tooling, and `golang.org/x/*`, while GitHub Actions checks run an hour later with scoped `ci` commit prefixes so dependency maintenance stays organized without overwhelming the queue.